### PR TITLE
Add simple FastAPI PostgreSQL browser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-FastAdmin
+# FastAdmin
+
+Simple FastAPI app to browse tables from any PostgreSQL database.
+
+## Usage
+
+1. Edit `docker-compose.yml` or set the database URL when connecting.
+2. Run the application:
+
+```bash
+docker compose up --build
+```
+
+3. Open `http://localhost:8000` in your browser and enter the PostgreSQL connection URL. Example:
+
+```
+postgresql://user:password@hostname:5432/dbname
+```
+
+The app will read all tables, save their schemas to `schema.json` and display the table list. Select a table from the sidebar to view its contents.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,52 @@
+from fastapi import FastAPI, Request, Form, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import create_engine, MetaData
+import json
+from pathlib import Path
+
+app = FastAPI()
+templates = Jinja2Templates(directory='templates')
+SCHEMA_PATH = Path('schema.json')
+db_engine = None
+
+@app.get('/', response_class=HTMLResponse)
+def index(request: Request):
+    global db_engine
+    if db_engine is None:
+        return templates.TemplateResponse('index.html', {'request': request, 'connected': False})
+    metadata = MetaData()
+    metadata.reflect(bind=db_engine)
+    tables = list(metadata.tables.keys())
+    return templates.TemplateResponse('tables.html', {'request': request, 'tables': tables})
+
+@app.post('/connect', response_class=HTMLResponse)
+def connect(request: Request, db_url: str = Form(...)):
+    global db_engine
+    try:
+        db_engine = create_engine(db_url)
+        metadata = MetaData()
+        metadata.reflect(bind=db_engine)
+        tables = list(metadata.tables.keys())
+        schemas = {t: [c.name for c in metadata.tables[t].columns] for t in tables}
+        SCHEMA_PATH.write_text(json.dumps(schemas, indent=2))
+        return templates.TemplateResponse('tables.html', {'request': request, 'tables': tables})
+    except Exception as exc:
+        db_engine = None
+        return templates.TemplateResponse('index.html', {'request': request, 'connected': False, 'error': str(exc)})
+
+@app.get('/table/{name}', response_class=HTMLResponse)
+def show_table(name: str, request: Request):
+    global db_engine
+    if db_engine is None:
+        raise HTTPException(status_code=400, detail='Not connected')
+    metadata = MetaData()
+    metadata.reflect(bind=db_engine)
+    table = metadata.tables.get(name)
+    if table is None:
+        raise HTTPException(status_code=404, detail='Table not found')
+    with db_engine.connect() as conn:
+        rows = conn.execute(table.select().limit(100)).fetchall()
+    tables = list(metadata.tables.keys())
+    columns = [col.name for col in table.columns]
+    return templates.TemplateResponse('table.html', {'request': request, 'table': name, 'rows': rows, 'columns': columns, 'tables': tables})

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>FastAdmin</title>
+  <style>
+    body { display: flex; font-family: Arial, sans-serif; }
+    #sidebar { width: 200px; background: #f0f0f0; padding: 10px; }
+    #content { flex-grow: 1; padding: 10px; }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: 5px; }
+  </style>
+</head>
+<body>
+  <div id="sidebar">
+    {% block sidebar %}{% endblock %}
+  </div>
+  <div id="content">
+    {% block content %}{% endblock %}
+  </div>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Connect to Database</h1>
+{% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+<form action="/connect" method="post">
+  <input type="text" name="db_url" placeholder="postgresql://user:pass@host/dbname" style="width:100%" />
+  <button type="submit">Connect</button>
+</form>
+{% endblock %}

--- a/app/templates/table.html
+++ b/app/templates/table.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block sidebar %}
+<h3>Tables</h3>
+<ul>
+{% for name in tables %}
+<li><a href="/table/{{ name }}">{{ name }}</a></li>
+{% endfor %}
+</ul>
+{% endblock %}
+{% block content %}
+<h1>Table: {{ table }}</h1>
+<table border="1" cellspacing="0" cellpadding="5">
+  <thead>
+    <tr>
+    {% for col in columns %}
+      <th>{{ col }}</th>
+    {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr>
+      {% for col in columns %}
+      <td>{{ row[col] }}</td>
+      {% endfor %}
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/tables.html
+++ b/app/templates/tables.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block sidebar %}
+<h3>Tables</h3>
+<ul>
+{% for name in tables %}
+<li><a href="/table/{{ name }}">{{ name }}</a></li>
+{% endfor %}
+</ul>
+{% endblock %}
+{% block content %}
+<h1>Choose a table from the list</h1>
+{% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  fastadmin:
+    build: .
+    ports:
+      - "8000:8000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+jinja2
+sqlalchemy
+psycopg2-binary


### PR DESCRIPTION
## Summary
- implement minimal FastAPI app to inspect a PostgreSQL database
- save table schemas to `schema.json`
- provide basic HTML templates for listing tables and viewing rows
- add Dockerfile and docker-compose setup
- document usage in README

## Testing
- `python3 -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68434d8ac4908331a153d03b6dca555e